### PR TITLE
y-label(ylab) is not correctly shown on the y-axis

### DIFF
--- a/R/console_plot.R
+++ b/R/console_plot.R
@@ -69,7 +69,7 @@ console.plot <- function(x, y = NULL, groups = NULL, main = NULL, file = "",
         m <- m + 1
       }
     }
-    ylab <- xlab
+    if (ylab == "NULL") ylab <- xlab
     if (is.null(xlab)) xlab <- "Index"
   } else if (length(y) != length(x))
     stop("x and y must have the same number of observations")


### PR DESCRIPTION
There is a bug when xlab, ylab is specified in the console.plot function, xlab is shown on the y-axis also and ylab is not shown on the y-axis. This PR fixes the problem